### PR TITLE
Update setup.xml

### DIFF
--- a/data/setup.xml
+++ b/data/setup.xml
@@ -25,7 +25,7 @@
 		<item level="1" text="EPG language selection 1" description="Configure the primary EPG language.">config.autolanguage.audio_epglanguage</item>
 		<item level="1" text="EPG language selection 2" conditional="config.autolanguage.audio_epglanguage.value" description="Configure the secondary EPG language.">config.autolanguage.audio_epglanguage_alternative</item>
 	</setup>
-	<setup key="ChannelSelection" title="Channel Selection Setup">
+	<setup key="channelselection" title="Channel Selection Setup">
 		<item level="1" text="Enable blinking" description="Enable blink functionality for some areas like record icon.">config.usage.enable_blinking</item>
 		<item level="1" text="Show positioner movement" requires="isRotorTuner" description="Configure whether or not an icon should be shown when your motorized dish is moving.">config.usage.showdish</item>
 		<item level="1" text="Show positioner position" requires="isRotorTuner" description="Configure whether or not a rotor position will be displayed on the infobar">config.misc.showrotorposition</item>


### PR DESCRIPTION
fix crashlog :
22:46:21.9442 Traceback (most recent call last):
22:46:21.9443   File "/usr/lib/enigma2/python/Components/ActionMap.py", line 61, in action
22:46:21.9449     res = self.actions[action]()
22:46:21.9453           ^^^^^^^^^^^^^^^^^^^^^^
22:46:21.9454   File "/usr/lib/enigma2/python/Screens/ChannelSelection.py", line 541, in okbuttonClick
22:46:21.9462   File "/usr/lib/enigma2/python/Screens/ChannelSelection.py", line 545, in openSetup
22:46:21.9468   File "/usr/lib/enigma2/python/StartEnigma.py", line 155, in openWithCallback
22:46:21.9474     dialog = self.open(screen, *arguments, **kwargs)
22:46:21.9478              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
22:46:21.9479   File "/usr/lib/enigma2/python/StartEnigma.py", line 166, in open
22:46:21.9484     dialog = self.current_dialog = self.instantiateDialog(screen, *arguments, **kwargs)
22:46:21.9488                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
22:46:21.9489   File "/usr/lib/enigma2/python/StartEnigma.py", line 105, in instantiateDialog
22:46:21.9493     return self.doInstantiateDialog(screen, arguments, kwargs, self.desktop)
22:46:21.9497            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
22:46:21.9498   File "/usr/lib/enigma2/python/StartEnigma.py", line 127, in doInstantiateDialog
22:46:21.9501     dialog = screen(self, *arguments, **kwargs)  # Create dialog.
22:46:21.9504              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
22:46:21.9505   File "/usr/lib/enigma2/python/Screens/Setup.py", line 86, in __init__
22:46:21.9515 AttributeError: 'Setup' object has no attribute 'setup'